### PR TITLE
Fixing issues in erase pop_back and pop_front

### DIFF
--- a/SimpleList/SimpleList.h
+++ b/SimpleList/SimpleList.h
@@ -85,7 +85,10 @@ public:
         if (empty())
         {
             if (!_preAlloc)
+            {
                 delete[] _list;
+                _list = NULL;
+            }
             return;
         }
 
@@ -112,7 +115,10 @@ public:
         if (empty())
         {
             if (!_preAlloc)
+            {
                 delete[] _list;
+                _list = NULL;
+            }
             return;
         }
 
@@ -157,7 +163,10 @@ public:
         if (empty())
         {
             if (!_preAlloc)
+            {
                 delete[] _list;
+                _list = NULL;
+            }
             return NULL;
         }
 
@@ -186,8 +195,10 @@ public:
             delete[] _list;
             _list = newBuffer;
         }
-
-        itr = _list + pos;
+        if(sum)
+          itr = _list + pos;
+        else
+          itr = _list + _size;
 
         return itr;
     }


### PR DESCRIPTION
Problem: When erasing the last element of a list the iterator was set to
_list + pos with pos = 0 because the for loop does not get to the last
element of the list so pos stays 0. This causes the calling loop to
iterate through the whole list again
Fix: If sum is still false after the for loop it now sets the iterator
to _list + _size which is the the end and the calling loop stops as
expected

Problem:  popping or erasing the last element of a list containing
only one element causes a memory violation
Fix: After deleting _list set it to NULL
